### PR TITLE
feat: adopt Konsist to ensure architecture correctness.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,7 +57,6 @@ android {
 }
 
 dependencies {
-
     implementation("androidx.core:core-ktx:1.10.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.1")
     implementation("androidx.activity:activity-compose:1.7.2")
@@ -89,4 +88,7 @@ dependencies {
     implementation("androidx.room:room-ktx:$roomVersion")
     implementation(kotlin("reflect"))
     implementation("androidx.core:core-splashscreen:1.0.0")
+
+    // Konsist
+    testImplementation("com.lemonappdev:konsist:0.15.1")
 }

--- a/app/src/main/java/studio/jasonsu/myfitness/domain/usecase/UserNameUseCase.kt
+++ b/app/src/main/java/studio/jasonsu/myfitness/domain/usecase/UserNameUseCase.kt
@@ -1,4 +1,4 @@
-package studio.jasonsu.myfitness.domain
+package studio.jasonsu.myfitness.domain.usecase
 
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf

--- a/app/src/test/java/studio/jasonsu/myfitness/ArchitectureUnitTest.kt
+++ b/app/src/test/java/studio/jasonsu/myfitness/ArchitectureUnitTest.kt
@@ -1,0 +1,94 @@
+package studio.jasonsu.myfitness
+
+import androidx.lifecycle.ViewModel
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.architecture.KoArchitectureCreator.assertArchitecture
+import com.lemonappdev.konsist.api.architecture.Layer
+import com.lemonappdev.konsist.api.ext.list.withAllParentsOf
+import com.lemonappdev.konsist.api.ext.list.withNameEndingWith
+import com.lemonappdev.konsist.api.verify.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ArchitectureUnitTest {
+
+    private lateinit var ui: Layer
+    private lateinit var domain: Layer
+    private lateinit var repository: Layer
+    private lateinit var datasource: Layer
+    private lateinit var database: Layer
+
+    @Before
+    fun before() {
+        ui = Layer("UI", "studio.jasonsu.myfitness.ui..")
+        domain = Layer("Domain", "studio.jasonsu.myfitness.domain..")
+        repository = Layer("Repository", "studio.jasonsu.myfitness.repository..")
+        datasource = Layer("Datasource", "studio.jasonsu.myfitness.datasource..")
+        database = Layer("Database", "studio.jasonsu.myfitness.database..")
+    }
+
+    @Test
+    fun `classes with 'UseCase' suffix should reside in 'usecase' package`() {
+        Konsist.scopeFromProject()
+            .classes()
+            .withNameEndingWith("UseCase")
+            .assertTrue { it.resideInPackage("..usecase..") }
+    }
+
+    @Test
+    fun `classes extending 'ViewModel' should have 'ViewModel' suffix`() {
+        Konsist.scopeFromProject()
+            .classes()
+            .withAllParentsOf(ViewModel::class)
+            .assertTrue { it.name.endsWith("ViewModel") }
+    }
+
+
+    @Test
+    fun `UI layers should depend on Domain, Repository, and Datasource layers`() {
+        Konsist
+            .scopeFromProduction()
+            .assertArchitecture {
+                ui.dependsOn(domain)
+                ui.dependsOn(repository)
+                ui.dependsOn(datasource)
+            }
+    }
+
+    @Test
+    fun `Domain layers should depend on Repository layers`() {
+        Konsist
+            .scopeFromProduction()
+            .assertArchitecture {
+                domain.dependsOn(repository)
+            }
+    }
+
+    @Test
+    fun `Repository layers should depend on Datasource and Database layers`() {
+        Konsist
+            .scopeFromProduction()
+            .assertArchitecture {
+                repository.dependsOn(datasource)
+                repository.dependsOn(database)
+            }
+    }
+
+    @Test
+    fun `Datasource layers should depend on Database layers`() {
+        Konsist
+            .scopeFromProduction()
+            .assertArchitecture {
+                datasource.dependsOn(database)
+            }
+    }
+
+    @Test
+    fun `Database layers should not depend on anything`() {
+        Konsist
+            .scopeFromProduction()
+            .assertArchitecture {
+                database.dependsOnNothing()
+            }
+    }
+}


### PR DESCRIPTION
# Changes made
- Imported [Konsist](https://github.com/LemonAppDev/konsist) version  `0.15.1`.
- Created `ArchitectureUnitTest` which tested the following architecture rules: 
  - classes with 'UseCase' suffix should reside in 'usecase' package.
  - classes extending 'ViewModel' should have 'ViewModel' suffix.
  - UI layers should depend on Domain, Repository, and Datasource layers.
  - Domain layers should depend on Repository layers.
  - Repository layers should depend on Datasource and Database layers.
  - Datasource layers should depend on Database layers.
  - Database layers should not depend on anything.