### PR TITLE
feat: In App update

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -91,4 +91,8 @@ dependencies {
 
     // Konsist
     testImplementation("com.lemonappdev:konsist:0.15.1")
+
+    // In-app Update
+    implementation("com.google.android.play:app-update:2.1.0")
+    implementation("com.google.android.play:app-update-ktx:2.1.0")
 }

--- a/app/src/main/java/studio/jasonsu/myfitness/MainActivity.kt
+++ b/app/src/main/java/studio/jasonsu/myfitness/MainActivity.kt
@@ -72,14 +72,6 @@ class MainActivity : MyFitnessActivity() {
         inAppUpdateHelper.onDestroy()
     }
 
-    @Deprecated("Deprecated in Java")
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-        if (inAppUpdateHelper.onActivityResult(requestCode, resultCode, data)) {
-            return
-        }
-    }
-
     private fun handleForegroundLessonAlarm(intent: Intent) {
         val lessonAlarm = getLessonAlarm(intent)
         if (lessonAlarm == null) {

--- a/app/src/main/java/studio/jasonsu/myfitness/MainActivity.kt
+++ b/app/src/main/java/studio/jasonsu/myfitness/MainActivity.kt
@@ -7,7 +7,9 @@ import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
 import studio.jasonsu.myfitness.app.MyFitnessApp
+import studio.jasonsu.myfitness.autoupdate.InAppUpdateHelper
 import studio.jasonsu.myfitness.broadcast.LessonAlarmBroadcastReceiver.Companion.FOREGROUND_LESSON_ALARM_ACTION
 import studio.jasonsu.myfitness.broadcast.LessonAlarmBroadcastReceiver.Companion.LESSON_ALARM_EXTRA_KEY
 import studio.jasonsu.myfitness.model.LessonAlarm
@@ -26,6 +28,8 @@ class MainActivity : MyFitnessActivity() {
         }
     )
 
+    private val inAppUpdateHelper by lazy { InAppUpdateHelper(this, lifecycleScope) }
+
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
         Log.d(TAG, "onNewIntent: intent=$intent")
@@ -37,6 +41,7 @@ class MainActivity : MyFitnessActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
+        inAppUpdateHelper.onCreate()
         mainViewModel = ViewModelProvider(this)[MainViewModel::class.java]
         mainViewModel.isReady.observe(this) { isReady ->
             splashScreen.setKeepOnScreenCondition { !isReady }
@@ -54,6 +59,24 @@ class MainActivity : MyFitnessActivity() {
                 mainViewModel = mainViewModel,
                 onFinished = ::finish
             )
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        inAppUpdateHelper.onResume()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        inAppUpdateHelper.onDestroy()
+    }
+
+    @Deprecated("Deprecated in Java")
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (inAppUpdateHelper.onActivityResult(requestCode, resultCode, data)) {
+            return
         }
     }
 

--- a/app/src/main/java/studio/jasonsu/myfitness/autoupdate/InAppUpdateHelper.kt
+++ b/app/src/main/java/studio/jasonsu/myfitness/autoupdate/InAppUpdateHelper.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import studio.jasonsu.myfitness.MainActivity
 import studio.jasonsu.myfitness.MainActivity.Companion.TAG
+import studio.jasonsu.myfitness.R
 import kotlin.time.Duration.Companion.seconds
 
 class InAppUpdateHelper(
@@ -31,7 +32,7 @@ class InAppUpdateHelper(
         activity.registerForActivityResult(
             ActivityResultContracts.StartIntentSenderForResult()
         ) { result ->
-            if (result.resultCode == RESULT_OK) {
+            if (result.resultCode != RESULT_OK) {
                 Log.e(TAG, "Update failed! Please check the update process for potential issues.")
                 if (appUpdateType == AppUpdateType.IMMEDIATE) {
                     activity.finish()
@@ -44,7 +45,7 @@ class InAppUpdateHelper(
         if (state.installStatus() == InstallStatus.DOWNLOADED) {
             Toast.makeText(
                 activity.applicationContext,
-                "下載成功. 將在5秒後自動重啟！",
+                activity.getString(R.string.in_app_update_success_message),
                 Toast.LENGTH_LONG
             ).show()
             scope.launch {
@@ -66,7 +67,7 @@ class InAppUpdateHelper(
                 appUpdateManager.startUpdateFlowForResult(
                     info,
                     inAppUpdateLauncher,
-                    AppUpdateOptions.newBuilder(AppUpdateType.FLEXIBLE).build()
+                    AppUpdateOptions.newBuilder(appUpdateType).build()
                 )
             }
         }
@@ -86,7 +87,7 @@ class InAppUpdateHelper(
                     appUpdateManager.startUpdateFlowForResult(
                         info,
                         inAppUpdateLauncher,
-                        AppUpdateOptions.newBuilder(AppUpdateType.IMMEDIATE).build()
+                        AppUpdateOptions.newBuilder(appUpdateType).build()
                     )
                 }
             }

--- a/app/src/main/java/studio/jasonsu/myfitness/autoupdate/InAppUpdateHelper.kt
+++ b/app/src/main/java/studio/jasonsu/myfitness/autoupdate/InAppUpdateHelper.kt
@@ -1,0 +1,90 @@
+package studio.jasonsu.myfitness.autoupdate
+
+import android.content.Intent
+import android.util.Log
+import android.widget.Toast
+import androidx.activity.ComponentActivity.RESULT_OK
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.install.InstallStateUpdatedListener
+import com.google.android.play.core.install.model.AppUpdateType
+import com.google.android.play.core.install.model.InstallStatus
+import com.google.android.play.core.install.model.UpdateAvailability
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import studio.jasonsu.myfitness.MainActivity
+import studio.jasonsu.myfitness.MainActivity.Companion.TAG
+import kotlin.time.Duration.Companion.seconds
+
+class InAppUpdateHelper(
+    private val activity: MainActivity,
+    private val scope: CoroutineScope
+) {
+    private val appUpdateManager by lazy { AppUpdateManagerFactory.create(activity.applicationContext) }
+
+    private var appUpdateType = AppUpdateType.FLEXIBLE
+
+    private val installStateUpdatedListener = InstallStateUpdatedListener { state ->
+        if (state.installStatus() == InstallStatus.DOWNLOADED) {
+            Toast.makeText(
+                activity.applicationContext,
+                "下載成功. 將在5秒後自動重啟！",
+                Toast.LENGTH_LONG
+            ).show()
+            scope.launch {
+                delay(5.seconds)
+                appUpdateManager.completeUpdate()
+            }
+        }
+    }
+
+    private fun checkInAppUpdate() {
+        appUpdateManager.appUpdateInfo.addOnSuccessListener { info ->
+            val isUpdateAvailable = info.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE
+            val isUpdateAllowed = when (appUpdateType) {
+                AppUpdateType.IMMEDIATE -> info.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)
+                AppUpdateType.FLEXIBLE -> info.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)
+                else -> false
+            }
+            if (isUpdateAvailable && isUpdateAllowed) {
+                appUpdateManager.startUpdateFlowForResult(info, appUpdateType, activity, 100)
+            }
+        }
+    }
+
+    fun onCreate() {
+        if (appUpdateType == AppUpdateType.FLEXIBLE) {
+            appUpdateManager.registerListener(installStateUpdatedListener)
+        }
+        checkInAppUpdate()
+    }
+
+    fun onResume() {
+        if (appUpdateType == AppUpdateType.IMMEDIATE) {
+            appUpdateManager.appUpdateInfo.addOnSuccessListener { info ->
+                if (info.updateAvailability() == UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS) {
+                    appUpdateManager.startUpdateFlowForResult(info, appUpdateType, activity, 100)
+                }
+            }
+        }
+    }
+
+    fun onDestroy() {
+        if (appUpdateType == AppUpdateType.FLEXIBLE) {
+            appUpdateManager.unregisterListener(installStateUpdatedListener)
+        }
+    }
+
+    fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+        if (requestCode == 100) {
+            if (resultCode != RESULT_OK) {
+                Log.e(TAG, "Something went wrong with the updating...")
+                if (appUpdateType == AppUpdateType.IMMEDIATE) {
+                    activity.finish()
+                }
+            }
+            return true
+        }
+        return false
+    }
+}

--- a/app/src/main/java/studio/jasonsu/myfitness/autoupdate/InAppUpdateHelper.kt
+++ b/app/src/main/java/studio/jasonsu/myfitness/autoupdate/InAppUpdateHelper.kt
@@ -47,7 +47,7 @@ class InAppUpdateHelper(
                 else -> false
             }
             if (isUpdateAvailable && isUpdateAllowed) {
-                appUpdateManager.startUpdateFlowForResult(info, appUpdateType, activity, 100)
+                appUpdateManager.startUpdateFlowForResult(info, appUpdateType, activity, UPDATE_REQUEST_CODE)
             }
         }
     }
@@ -76,9 +76,9 @@ class InAppUpdateHelper(
     }
 
     fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
-        if (requestCode == 100) {
+        if (requestCode == UPDATE_REQUEST_CODE) {
             if (resultCode != RESULT_OK) {
-                Log.e(TAG, "Something went wrong with the updating...")
+                Log.e(TAG, "Update failed with resultCode: $resultCode. Please check the update process for potential issues.")
                 if (appUpdateType == AppUpdateType.IMMEDIATE) {
                     activity.finish()
                 }
@@ -86,5 +86,9 @@ class InAppUpdateHelper(
             return true
         }
         return false
+    }
+
+    companion object {
+        private const val UPDATE_REQUEST_CODE = 100
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">運動小幫手</string>
+    <string name="in_app_update_success_message">下載成功. 將在5秒後自動重啟！</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
     <string name="app_name">運動小幫手</string>
-    <string name="in_app_update_success_message">下載成功. 將在5秒後自動重啟！</string>
+    <string name="in_app_update_success_message">下載成功。將在5秒後自動重啟！</string>
 </resources>


### PR DESCRIPTION
Adds support for Google Play In-App Updates via a new helper and lifecycle integration.

- Introduce `InAppUpdateHelper` for managing both flexible and immediate update flows.
- Hook update checks into `MainActivity`’s lifecycle (`onCreate`, `onResume`, `onDestroy`).
- Add Play Core update dependencies in `build.gradle.kts`.

| File                                             | Description                                           |
| ------------------------------------------------ | ----------------------------------------------------- |
| app/src/main/java/studio/jasonsu/myfitness/autoupdate/InAppUpdateHelper.kt | New helper class implementing in-app update logic.    |
| app/src/main/java/studio/jasonsu/myfitness/MainActivity.kt                 | Integrate `InAppUpdateHelper` into activity lifecycle.|
| app/build.gradle.kts                              | Add Play Core in-app update dependencies.             |
