### PR TITLE
Update compileSdk and targetSdk to 35

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,12 +7,12 @@ plugins {
 
 android {
     namespace = "studio.jasonsu.myfitness"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "studio.jasonsu.myfitness"
         minSdk = 24
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 2
         versionName = "1.0"
 


### PR DESCRIPTION
# Change made:
- Update `compileSdk` and `targetSdk` to 35 to meet the minimum SDK version required by Google Play Policy.